### PR TITLE
Pin pythonnet to 2.5.2 (or compatible) in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
-    install_requires=['pythonnet', 'PyYAML'],
+    install_requires=['pythonnet~=2.5.2', 'PyYAML'],
     tests_require=['pytest', 'numpy'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Similar to what was done in requirements.txt, pin the version of pythonnet to 2.5.2 or compatible.

### Why should this Pull Request be merged?

When testing the built WHL file, I noticed that pythonnet 3 was still installed despite updating requirements.txt. It turns out that we need to update `install_requires` in setup.py as well.

### What testing has been done?

Built locally (via `python setup.py bdist_wheel --universal`) and installed the WHL file using pip on a clean venv.